### PR TITLE
ci: disable Homebrew Linux sandbox in test-bot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,12 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
+    env:
+      # The GitHub Actions runners enable the Homebrew Linux sandbox but do not
+      # ship the `bwrap` (Bubblewrap) executable it requires, which makes
+      # `brew doctor` (run by `brew test-bot --only-setup`) fail. Disable the
+      # Linux sandbox to work around it. No-op on macOS runners.
+      HOMEBREW_NO_SANDBOX_LINUX: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
## Problem

`test-bot` matrix jobs (e.g. on #582) fail on the `brew test-bot --only-setup` step, which runs `brew doctor`:

```
==> brew doctor
==> FAILED
Bubblewrap is required to use the Linux sandbox but was not found.
...
As a final workaround, disable the Linux sandbox:
  export HOMEBREW_NO_SANDBOX_LINUX=1
Error: 1 failed step!
brew doctor
```

The GitHub Actions runners enable `HOMEBREW_SANDBOX_LINUX` but do not ship the `bwrap` (Bubblewrap) executable it requires, so `brew doctor` errors out before any bottle is built. When the ubuntu-22.04 job fails fast, the rest of the matrix gets cancelled.

## Fix

Set `HOMEBREW_NO_SANDBOX_LINUX=1` at the job level in `tests.yml` (the workaround the error itself recommends). No-op on the macOS runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)