### PR TITLE
feat: publish bottles for the nuon formula

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -23,9 +23,16 @@ jobs:
       - name: Save version
         run: |
           echo "$VERSION" > version.txt
+      - name: Build bottles
+        run: |
+          ./scripts/bottle.sh "$VERSION" "$RUNNER_TEMP/bottles"
+      - name: Publish bottles
+        run: |
+          gh release view "bottles-${VERSION}" >/dev/null 2>&1 || gh release create "bottles-${VERSION}" --target main --title "bottles-${VERSION}" --notes "Homebrew bottles for nuon ${VERSION}"
+          gh release upload "bottles-${VERSION}" "$RUNNER_TEMP"/bottles/*.tar.gz --clobber
       - name: Generate
         run: |
-          ./scripts/generate.sh "$VERSION"
+          BOTTLE_SHAS_FILE="$RUNNER_TEMP/bottles/shas.env" ./scripts/generate.sh "$VERSION"
       - name: Commit changes
         run: |
           git checkout -b "nuonbot/generate-${VERSION}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,11 @@ jobs:
       # `brew doctor` (run by `brew test-bot --only-setup`) fail. Disable the
       # Linux sandbox to work around it. No-op on macOS runners.
       HOMEBREW_NO_SANDBOX_LINUX: 1
+      # Homebrew 6's build sandbox cannot read ~/.homebrew/trust.json, so
+      # source builds from third-party taps fail even when trusted
+      # (https://github.com/Homebrew/brew/issues/22699). Remove once the
+      # upstream fix (Homebrew/brew#22700) ships.
+      HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nuon
+bottles/

--- a/Formula/nuon.rb
+++ b/Formula/nuon.rb
@@ -3,6 +3,14 @@ class Nuon < Formula
   homepage "https://www.nuon.co/"
   version "0.19.1001"
 
+  bottle do
+    root_url "https://github.com/nuonco/homebrew-tap/releases/download/bottles-0.19.1001"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "5458a259f253cc659bf45aecaec1657af0784b450df516dc3b09aaee0a3c2d1d"
+    sha256 cellar: :any_skip_relocation, big_sur:       "95201139a39f89c15a11422e4da694441887021b7e6d6ae4de872b777a89be7e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d44f7fcd057241c671b350257494e2f742f9e63bae3f5e7afb631a5101645d6d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9ad30904d0e018894015255137ba7ca9c46e1ae08188796624cb492e924457b5"
+  end
+
   # CLI binary
   if OS.mac? && Hardware::CPU.intel?
     url "https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli/0.19.1001/nuon_darwin_amd64"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 Or `brew tap nuonco/tap` and then `brew install nuon`.
 
+On Homebrew 6 or later, third-party taps must be trusted first:
+
+```sh
+brew trust nuonco/tap
+brew install nuonco/tap/nuon
+```
+
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).

--- a/scripts/bottle.sh
+++ b/scripts/bottle.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# shellcheck disable=SC2250,SC2312
+#
+# Build Homebrew bottles for the nuon formula by repackaging the prebuilt
+# binaries from S3. Bottles let `brew install` pour a tarball directly
+# instead of running the sandboxed build phase.
+#
+# Usage: ./scripts/bottle.sh <version> [output-dir]
+#
+# Writes per-platform tarballs named `nuon-<version>.<tag>.bottle.tar.gz`
+# (the exact filename Homebrew requests under the formula's root_url) and a
+# `shas.env` file consumed by generate.sh.
+
+set -euo pipefail
+
+version=$1
+outdir=${2:-bottles}
+
+cli_artifact_url="https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli/$version"
+lsp_artifact_url="https://nuon-artifacts.s3.us-west-2.amazonaws.com/lsp/$version"
+
+cli_checksum_file=$(curl -fsS "$cli_artifact_url/checksums.txt")
+lsp_checksum_file=$(curl -fsS "$lsp_artifact_url/checksums.txt" || true)
+if echo "$lsp_checksum_file" | grep -q "nuon-lsp"; then
+  has_lsp=true
+else
+  has_lsp=false
+fi
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# Download $1 to $2 and verify it against the sha listed in $3 (checksums.txt content).
+fetch_verified() {
+  local url=$1 dest=$2 checksums=$3
+  local file expected actual
+  file=$(basename "$url")
+  curl -fsSL "$url" -o "$dest"
+  expected=$(echo "$checksums" | grep "${file}$" | cut -b -64)
+  actual=$(sha256_of "$dest")
+  if [ -z "$expected" ] || [ "$expected" != "$actual" ]; then
+    echo "checksum mismatch for $file: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$outdir"
+shas_file="$outdir/shas.env"
+: >"$shas_file"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+# bottle tag -> artifact platform suffix
+#
+# Homebrew pours a bottle tagged for an older macOS on any newer macOS with
+# the same architecture, so tagging with big_sur (macOS 11, the oldest
+# version Homebrew still recognises) covers every mac user. Linux tags are
+# distro-independent. 32-bit ARM Linux has no bottle tag; those users keep
+# building from source.
+bottle_platforms="
+arm64_big_sur darwin_arm64
+big_sur darwin_amd64
+x86_64_linux linux_amd64
+arm64_linux linux_arm64
+"
+
+echo "$bottle_platforms" | while read -r tag platform; do
+  [ -z "$tag" ] && continue
+
+  keg="$workdir/$tag/nuon/$version"
+  mkdir -p "$keg/bin"
+
+  fetch_verified "$cli_artifact_url/nuon_$platform" "$keg/bin/nuon" "$cli_checksum_file"
+  chmod 0555 "$keg/bin/nuon"
+
+  if [ "$has_lsp" = true ]; then
+    fetch_verified "$lsp_artifact_url/nuon-lsp_$platform" "$keg/bin/nuon-lsp" "$lsp_checksum_file"
+    chmod 0555 "$keg/bin/nuon-lsp"
+  fi
+
+  tarball="$outdir/nuon-$version.$tag.bottle.tar.gz"
+  tar -czf "$tarball" -C "$workdir/$tag" nuon
+  echo "BOTTLE_SHA_$tag=$(sha256_of "$tarball")" >>"$shas_file"
+  echo "✅ built $tarball"
+done
+
+cat "$shas_file"

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -5,6 +5,12 @@ version=$1
 cli_artifact_url="https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli/$version"
 lsp_artifact_url="https://nuon-artifacts.s3.us-west-2.amazonaws.com/lsp/$version"
 
+# Bottle checksums produced by scripts/bottle.sh (optional). When present,
+# the formula gets a bottle block so `brew install` pours a prebuilt tarball
+# instead of running the sandboxed build phase.
+bottle_shas_file=${BOTTLE_SHAS_FILE:-bottles/shas.env}
+bottle_root_url=${BOTTLE_ROOT_URL:-https://github.com/nuonco/homebrew-tap/releases/download/bottles-$version}
+
 # Fetch CLI checksums
 cli_checksum_file=$(curl -s "$cli_artifact_url/checksums.txt")
 nuon_darwin_amd64_checksum=$(echo "$cli_checksum_file" | grep "nuon_darwin_amd64$" | cut -b -64)
@@ -40,6 +46,28 @@ class Nuon < Formula
   desc "${desc_text}"
   homepage "https://www.nuon.co/"
   version "${version}"
+EOL
+
+# Add bottle block if bottle checksums are available
+if [ -f "$bottle_shas_file" ]; then
+  # shellcheck disable=SC1090
+  source "$bottle_shas_file"
+  cat >>./Formula/nuon.rb <<EOL
+
+  bottle do
+    root_url "${bottle_root_url}"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "${BOTTLE_SHA_arm64_big_sur}"
+    sha256 cellar: :any_skip_relocation, big_sur:       "${BOTTLE_SHA_big_sur}"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "${BOTTLE_SHA_x86_64_linux}"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "${BOTTLE_SHA_arm64_linux}"
+  end
+EOL
+  echo "✅ Bottle block added to formula"
+else
+  echo "⚠️  No bottle checksums found at $bottle_shas_file, generating formula without bottles"
+fi
+
+cat >>./Formula/nuon.rb <<EOL
 
   # CLI binary
   if OS.mac? && Hardware::CPU.intel?


### PR DESCRIPTION
Homebrew 6 broke `brew install nuonco/tap/nuon` for all macOS users: the build sandbox can't read `~/.homebrew/trust.json`, so source builds fail with a silent exit 1 even when the tap is trusted (Homebrew/brew#22699, fix pending in Homebrew/brew#22700). Bottles are poured without the sandboxed build phase, which sidesteps the bug and speeds up installs.

- `scripts/bottle.sh` packs the prebuilt S3 binaries into per-platform bottle tarballs (arm64_big_sur/big_sur pour on every newer macOS, plus x86_64_linux and arm64_linux)
- `generate.yml` uploads them to a `bottles-<version>` release before opening the formula PR
- `tests.yml` sets `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` until the upstream fix ships

Verified on brew 6.0.1 / macOS arm64: `brew reinstall nuon` pours the bottle and the binaries work. Bottles for 0.19.1001 are uploaded already, so the formula change resolves on merge.