### PR TITLE
ci: skip bottle relocation to work around patchelf.rb regression

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,15 @@ jobs:
 
         # - run: brew test-bot --only-tap-syntax
 
-      - run: brew test-bot --only-formulae
+      # Our formulae install prebuilt Go binaries, so a bottle never needs
+      # relocating. Without `--skip-relocation`, `brew bottle` rewrites each
+      # binary's ELF interpreter via the vendored patchelf.rb gem, which as of
+      # 1.6.2 crashes on Go binaries whose single PT_NOTE segment spans both
+      # `.note.gnu.build-id` and `.note.go.buildid`:
+      #   Error: unsupported overlap of SHT_NOTE and PT_NOTE
+      # Skipping relocation bypasses patchelf entirely. Drop the flag once
+      # Homebrew ships a fixed patchelf.rb.
+      - run: brew test-bot --only-formulae --skip-relocation
         if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact


### PR DESCRIPTION
## Problem

`brew test-bot (ubuntu-24.04)` has failed on every formula PR since #695, blocking auto-merge:

```
==> Bottling nuon@0.19.1108--0.19.1108.x86_64_linux.bottle.tar.gz...
==> Detecting if ... is relocatable...
Error: unsupported overlap of SHT_NOTE and PT_NOTE
  patchelf-1.6.2/lib/patchelf/alt_saver.rb:1034 sync_note_segment
  ...
  dev-cmd/bottle.rb:602 bottle_formula
```

## Root cause — upstream, not ours

Homebrew bumped its vendored `patchelf` gem **1.5.2 → 1.6.2** in [`9eccee92e`](https://github.com/Homebrew/brew/commit/9eccee92e) at **2026-08-05 04:34 UTC**. 1.6.2 removed the `noted_phdrs` set from `write_replaced_sections`, so `sync_note_segment` no longer skips an already-synced `PT_NOTE`. It now raises on Go binaries where one `PT_NOTE` segment spans two note sections.

Ours does: `PT_NOTE` at `0x3a8–0x430` covers both `.note.gnu.build-id` (`0x3a8`+`0x24`) and `.note.go.buildid` (`0x3cc`+`0x64`). Normal for Go.

`brew bottle` trips it because it rewrites the interpreter from `/lib64/ld-linux-x86-64.so.2` to `/home/linuxbrew/.linuxbrew/lib/ld.so` — longer, so `.interp` must grow, forcing patchelf's section-rewrite path.

Timeline matches exactly:

| PR | Version | Ran | Homebrew | Result |
|---|---|---|---|---|
| #694 | 0.19.1105 | Aug 4 | `6.0.15-42` | ✅ |
| #695 | 0.19.1106 | Aug 5 10:14 | `6.0.15-96` | ❌ |
| #697 | 0.19.1108 | Aug 5 21:06 | `6.0.15-114` | ❌ |

**Our artifacts did not change.** The ELF layout of 0.19.1105 (green) and 0.19.1106 (red) is structurally identical — same 15 program headers, same `PT_NOTE` arrangement, same `.interp`, same `.dynstr`, no RPATH in either, same 50 sections. Only offsets shifted as the binary grew ~6KB. Same for `nuon-lsp`. The formula diff between them is version strings and sha256s only.

## Fix

Pass `--skip-relocation`, which gates out both relocation calls in `dev-cmd/bottle.rb`:

```ruby
499: changed_files = keg.replace_locations_with_placeholders unless args.skip_relocation?
602: keg.replace_placeholders_with_locations(changed_files) if changed_files && !args.skip_relocation?
```

Line 602 is the exact frame in the stack trace. patchelf is never invoked.

This is semantically correct, not just a mute: these formulae install **prebuilt** Go binaries, so a bottle never needs relocating. Rewriting the interpreter of a binary that already runs was pointless work.

## Why this is safe

- No formula in the tap declares a `bottle do` block (all 50), and none ever has.
- No release publishes bottle assets — the `--root-url` test-bot passes points at a release that doesn't exist.
- Version pinning is unaffected: `brew install nuonco/tap/nuon@0.19.1105` resolves the versioned formula, downloads from S3, verifies sha256. That path never touched a bottle.
- `brew install`, `brew style`, and `brew audit` coverage is unchanged — only the relocation sub-step of bottling is skipped.

## Notes

- `Could not symlink bin/nuon` will still appear (versioned + unversioned formulae collide on one symlink). test-bot already ignores it (`Warning: 1 failed step ignored!`); separate cleanup.
- The `Upload bottles as artifact` step was silently finding nothing; it will now upload throwaway artifacts. Harmless, still unused.
- Revert the flag once Homebrew ships a fixed patchelf.rb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)