### PR TITLE
ci: run formula checks directly instead of via brew test-bot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,23 +35,60 @@ jobs:
 
         # - run: brew test-bot --only-tap-syntax
 
-      # Our formulae install prebuilt Go binaries, so a bottle never needs
-      # relocating. Without `--skip-relocation`, `brew bottle` rewrites each
-      # binary's ELF interpreter via the vendored patchelf.rb gem, which as of
-      # 1.6.2 crashes on Go binaries whose single PT_NOTE segment spans both
-      # `.note.gnu.build-id` and `.note.go.buildid`:
+      # We deliberately do not use `brew test-bot --only-formulae` here.
+      #
+      # test-bot couples "test a formula" to "build a bottle", and Homebrew's
+      # patchelf.rb 1.5.2 -> 1.6.2 bump (brew 9eccee92e, 2026-08-05) made
+      # relocating our binaries crash. patchelf 1.6.2 raises on Go binaries
+      # whose single PT_NOTE segment spans both `.note.gnu.build-id` and
+      # `.note.go.buildid`, which is every binary we ship:
       #   Error: unsupported overlap of SHT_NOTE and PT_NOTE
-      # Skipping relocation bypasses patchelf entirely. Drop the flag once
-      # Homebrew ships a fixed patchelf.rb.
-      - run: brew test-bot --only-formulae --skip-relocation
+      #
+      # Neither test-bot flag helps: `--skip-relocation` only covers
+      # `brew bottle`, and test-bot then pours the bottle it just built and
+      # relocates again via `FormulaInstaller#pour`. `--build-from-source`
+      # makes `build_bottle?` false, which hits an unconditional
+      # `skipped ...; return` before install/style/audit -- CI goes green
+      # having tested nothing.
+      #
+      # The tap declares no bottles and publishes no bottle assets, so we lose
+      # nothing by skipping them and running the checks we actually want.
+      # Uninstalling between formulae also avoids the `nuon` /
+      # `nuon@<version>` symlink conflict test-bot used to warn about.
+      - name: Test changed formulae
         if: github.event_name == 'pull_request'
+        run: |
+          # No `mapfile`/`readarray` or other bash 4 builtins, and no `set -u`
+          # (it trips on empty arrays): the macOS runners still ship bash 3.2.
+          set -eo pipefail
 
-      - name: Upload bottles as artifact
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: bottles-${{ matrix.os }}
-          path: "*.bottle.*"
+          tap_dir="$(brew --repository nuonco/tap)"
+          git -C "$tap_dir" fetch -q origin main
+
+          formulae=()
+          while IFS= read -r formula; do
+            [ -n "$formula" ] && formulae+=("$formula")
+          done < <(
+            git -C "$tap_dir" diff --name-only --diff-filter=AM \
+              origin/main...HEAD -- 'Formula/*.rb' \
+              | sed -e 's|^Formula/||' -e 's|\.rb$||' -e 's|^|nuonco/tap/|'
+          )
+
+          if [ ${#formulae[@]} -eq 0 ]; then
+            echo "No formula changes in this PR; nothing to test."
+            exit 0
+          fi
+
+          printf 'Testing formula: %s\n' "${formulae[@]}"
+
+          brew style --formula "${formulae[@]}"
+          brew audit --formula --online --skip-style "${formulae[@]}"
+
+          for formula in "${formulae[@]}"; do
+            brew install --formula --verbose "$formula"
+            brew test --verbose "$formula"
+            brew uninstall --formula --force --ignore-dependencies "$formula"
+          done
 
   # On every `auto-merge` PR (opened by the generate workflow) report the
   # `brew test-bot` outcome: emit a Datadog counter tagged with the status so


### PR DESCRIPTION
Supersedes #698, which was insufficient. **Verified on a real formula change** — see below.

## Problem

`brew test-bot` couples "test a formula" to "build a bottle", and bottling broke when Homebrew bumped its vendored patchelf gem **1.5.2 → 1.6.2** ([`9eccee92e`](https://github.com/Homebrew/brew/commit/9eccee92e), 2026-08-05 04:34 UTC). 1.6.2 dropped the `noted_phdrs` bookkeeping in `write_replaced_sections`, so `sync_note_segment` now raises on Go binaries whose single `PT_NOTE` segment spans two note sections:

```
Error: unsupported overlap of SHT_NOTE and PT_NOTE
```

Every binary we ship qualifies: `PT_NOTE` at `0x3a8–0x430` covers both `.note.gnu.build-id` and `.note.go.buildid`. Normal for Go.

Our artifacts did not change — the ELF layout of 0.19.1105 (green) and 0.19.1106 (red) is structurally identical; only offsets shifted as the binary grew ~6KB.

## Why neither test-bot flag works

- **`--skip-relocation`** (#698) only gates `brew bottle`. test-bot then pours the bottle it just built, relocating again via `FormulaInstaller#pour` → identical crash.
- **`--build-from-source`** makes `build_bottle?` return false, which hits an unconditional `skipped ...; return` in `test_bot/formulae.rb:663` *before* install/style/audit. CI goes green having tested nothing — verified: both formulae reported `SKIPPED`, `No bottle built`.

There is no test-bot mode that tests a formula without bottling it.

## Fix

Run the checks directly: `brew style`, `brew audit --online`, then per formula `install` → `test` → `uninstall`.

Costs us nothing — the tap declares no bottles in any of its 50 formulae, has never had one in its history, and publishes no bottle assets (the `--root-url` test-bot passed pointed at a nonexistent release). Bottles were always discarded.

Version pinning is unaffected: `nuon@<version>` formulae install by downloading from S3 and verifying sha256, never via a bottle.

## Verified

Proven on #699, a throwaway branch carrying this change **plus** the 0.19.1108 formula, so `testing_formulae` was actually populated. All 5 platforms green, with real work confirmed in the logs:

```
Testing formula: nuonco/tap/nuon
Testing formula: nuonco/tap/nuon@0.19.1108
==> Testing nuonco/tap/nuon
==> .../bin/nuon version
0.19.1108
Uninstalling nuon... (5 files, 154.5MB)
==> Testing nuonco/tap/nuon@0.19.1108
Uninstalling nuon@0.19.1108... (5 files, 154.5MB)
```

No `Bottling`, no `SKIPPED`, no patchelf crash.

Note that #698's green run proved nothing: it changed no formula, so `testing_formulae` was `(none)`.

## Also fixed

- The `nuon` / `nuon@<version>` symlink conflict test-bot used to warn about (`Could not symlink bin/nuon`) — resolved by uninstalling between formulae.
- Dropped the now-dead bottle artifact upload step, which was already finding no files.
- Script avoids `mapfile` and `set -u`; macOS runners still ship bash 3.2 (that combination was exit code 127 / unbound-variable errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)